### PR TITLE
chore: add dependency: coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .mypy_cache/
 cover/
 coverage.xml
+.coverage
+ve*/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black;implementation_name=="cpython"
+coverage
 eventlet
 flake8
 flask


### PR DESCRIPTION
To eliminate the error as shown below:

```
% make test
nosetests -v flask_injector \
		--with-coverage --cover-package=flask_injector --cover-html --cover-branches --cover-xml
nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module
```